### PR TITLE
fix: rm dapr release milestone from proposal

### DIFF
--- a/0006-B-external-service-invocation.md
+++ b/0006-B-external-service-invocation.md
@@ -121,9 +121,6 @@ they can use an external URL and  optionally overwrite fields at the time of inv
 
 ### Feature lifecycle outline
 
-* Expectations
-This feature will be enabled after Dapr v1.11 release.
-
 * Compatability guarantees
 This feature is fully compatible with the existing service invocation API.
 


### PR DESCRIPTION
Remove Dapr release milestone from proposal that was merged yesterday proposing the extension of service invocation to non-Dapr endpoints.

https://github.com/dapr/proposals/pull/20