### PR TITLE
Change `DAPR_GRPC_ENDPOINT` to infer TLS based on query parameter

### DIFF
--- a/0008-S-sidecar-endpoint-tls.md
+++ b/0008-S-sidecar-endpoint-tls.md
@@ -67,12 +67,12 @@ Cons:
 
 ### Design
 
-* `DAPR_GRPC_ENDPOINT` defines entire endpoit for gRPC, not just host: `https://dapr-grpc.mycompany.com`
-* `DAPR_HTTP_ENDPOINT` defines entire endpoit for HTTP, not just host: `https://dapr-http.mycompany.com`
-* Port is parsed from the URL (`https://dapr.mycompany.com:8080`) or via the default port of the protocol used in the URL (80 for `http` and 443 for `https`)
+* `DAPR_GRPC_ENDPOINT` defines entire endpoint for gRPC, not just host: `dapr-grpc.mycompany.com`. No port in the URL defaults to 443.
+* `DAPR_HTTP_ENDPOINT` defines entire endpoint for HTTP, not just host: `https://dapr-http.mycompany.com`
+* Port is parsed from the hostport string (`dapr.mycompany.com:8080`) or via the default port of the protocol used in the URL (80 for `plaintext` and 443 for `TLS`)
 * `DAPR_GRPC_ENDPOINT` and `DAPR_HTTP_ENDPOINT` can be set at the same time since some SDKs (Java, as of now) supports both protocols at the same time and app can pick which one to use.
-* `DAPR_GRPC_ENDPOINT` and `DAPR_HTTP_ENDPOINT` must be parsed and the protocol will be used for SDK to determine if communication is over TLS (if not done automatically). In summary, `https` means secure channel.
-* Initially, only `http` and `https` protocols should be supported. Other protocols can be added in the future depending on each language support.
+* `DAPR_HTTP_ENDPOINT` must be parsed and the protocol will be used by SDK to determine if communication is over TLS (if not done automatically). In summary, `https` means secure channel.
+* `DAPR_GRPC_ENDPOINT` must be parsed and the query parameter will be used to determine whether the endpoint uses TLS. In summary, `?tls=true` means to use TLS. An empty query parameter defaults TLS based on port (`TLS` when port is 443, `plaintext` otherwise). SDKs should error on unrecognised or invalid query parameters.
 * `DAPR_GRPC_ENDPOINT` and `DAPR_HTTP_ENDPOINT` have priority over existing `DAPR_HOST` and `DAPR_HTTP_PORT` or `DAPR_GRPC_PORT` environment variables. Application's hardcoded values passed via constructor takes priority over any environment variable. In summary, this is the priority list (highest on top):
   1. Values passed via constructor or builder method.
   2. Properties or any other language specific configuration framework.
@@ -87,6 +87,9 @@ https://github.com/dapr/java-sdk/blob/76aec01e9aa4af7a72b910d77685ddd3f0bf86f3/s
 
 * Compatability guarantees
 This feature should allow localhost definition too `http://127.0.0.1:3500`, for example.
+
+this feature should continue to allow using other resolvers other than DNS (e.g.
+`unix://`).
 
 * Deprecation / co-existence with existing functionality
 This feature takes priority over existing (inconsistent) environment variables from each SDK. If app provides a hardcoded value for Dapr endpoint (via constructor, for example), it takes priority.


### PR DESCRIPTION
In the current proposal, SDKs are meant to enable TLS on gRPC endpoints based on the scheme being `https`. This is wrong- gRPC uses the scheme to determine which [resolver](https://github.com/grpc/grpc/blob/master/doc/naming.md) to use. Not only is wrong w.r.t to the gRPC protocol, is always means users will not be able to use other resolvers (e.g. `unix://`) in conjunction with `TLS`.

This PR updates the proposal so that the `DAPR_GRPC_ENDPOINT` URL now includes an optional `?tls=<bool>` parameter. This parameter signals to the SDK whether to enable `TLS` on this endpoint or not. The SDK will continue to infer whether to use `TLS` or not based on the endpoint port when this parameter is not present. `DAPR_GRPC_ENDPOINT` defaults to port `443` if not present.